### PR TITLE
Remove 2021-1 jars when running`isabelle jedit`

### DIFF
--- a/src/Tools/jEdit/lib/Tools/jedit
+++ b/src/Tools/jEdit/lib/Tools/jedit
@@ -268,6 +268,9 @@ declare -a JEDIT_BUILD_JARS=(
   "jsr305-2.0.0.jar"
 )
 
+# Isabelle 2021-1 introduces a different scheme for the plugin jars, which
+# breaks Isabelle 2021 jedit runs. Clean those up, so 2021 can run again:
+rm -rf ~/.isabelle/jedit/jars/isabelle_jedit_*.jar
 
 # target
 


### PR DESCRIPTION
In Isabelle 2021-1, the jEdit plugin system changed, and some new jars
are copied directly to `~/.isabelle/jedit/jars`. These jars stop
Isabelle 2021 jedit from working, so let's remove them. Isabelle 2021-1
happily replaces them anyway.

Signed-off-by: Rafal Kolanski <rafal.kolanski@proofcraft.systems>