### PR TITLE
output panel: print results with "Proof state" off

### DIFF
--- a/src/Tools/jEdit/src/output_dockable.scala
+++ b/src/Tools/jEdit/src/output_dockable.scala
@@ -48,7 +48,7 @@ class Output_Dockable(view: View, position: String) extends Dockable(view, posit
 
       val new_output =
         if (restriction.isEmpty || restriction.get.contains(command))
-          Rendering.output_messages(results, JEdit_Options.output_state())
+          Rendering.output_messages(results, true)
         else current_output
 
       if (current_output != new_output) {


### PR DESCRIPTION
Addresses regression whereby having a separate State panel and setting "Proof state" to off resulted in results being withheld from the Output buffer, i.e. "lemmas" commands didn't print anything.

The reason this fix works is because the "Proof state" option sets the global "editor_output_state" option which already prevents any proof state of making it into the Output panel's messages. Asking output_messages to filter again only results in throwing away the remaining actual result messages.